### PR TITLE
発着信音の分割, 呼出音のカスタマイズ

### DIFF
--- a/app/src/main/java/io/github/hiro/lime/LimeOptions.java
+++ b/app/src/main/java/io/github/hiro/lime/LimeOptions.java
@@ -40,9 +40,10 @@ public class LimeOptions {
     public Option outputCommunication = new Option("output_communication", R.string.switch_output_communication, false);
     public Option Archived = new Option("Archived_message", R.string.switch_archived, false);
     public Option removeAllServices = new Option("remove_Services", R.string.RemoveService, false);
-    public Option callTone = new Option("callTone", R.string.callTone, false);
-    public Option MuteTone = new Option("MuteTone", R.string.MuteTone, false);
-    public Option DialTone = new Option("DialTone", R.string.DialTone, false);
+    public Option DeviceCallTone = new Option("DeviceCallTone", R.string.DeviceCallTone, false);
+    public Option DeviceDialTone = new Option("DeviceDialTone", R.string.DeviceDialTone, false);
+    public Option MuteCallTone = new Option("MuteCallTone", R.string.MuteCallTone, false);
+    public Option MuteDialTone = new Option("MuteDialTone", R.string.MuteDialTone, false);
 
     public Option ReadChecker = new Option("ReadChecker", R.string.ReadChecker, false);
     public Option ReadCheckerChatdataDelete = new Option("ReadCheckerChatdataDelete", R.string.ReadCheckerChatdataDelete, false);
@@ -84,9 +85,10 @@ public class LimeOptions {
             blockTracking,
             stopVersionCheck,
             outputCommunication,
-            callTone,
-            MuteTone,
-            DialTone,
+            DeviceCallTone,
+            DeviceDialTone,
+            MuteCallTone,
+            MuteDialTone,
             DarkColor,
             MuteGroup,
             PhotoAddNotification,GroupNotification,

--- a/app/src/main/java/io/github/hiro/lime/LimeOptions.java
+++ b/app/src/main/java/io/github/hiro/lime/LimeOptions.java
@@ -41,9 +41,8 @@ public class LimeOptions {
     public Option Archived = new Option("Archived_message", R.string.switch_archived, false);
     public Option removeAllServices = new Option("remove_Services", R.string.RemoveService, false);
     public Option DeviceCallTone = new Option("DeviceCallTone", R.string.DeviceCallTone, false);
-    public Option DeviceDialTone = new Option("DeviceDialTone", R.string.DeviceDialTone, false);
     public Option MuteCallTone = new Option("MuteCallTone", R.string.MuteCallTone, false);
-    public Option MuteDialTone = new Option("MuteDialTone", R.string.MuteDialTone, false);
+    public Option CustomDialTone = new Option("CustomDialTone", R.string.CustomDialTone, false);
 
     public Option ReadChecker = new Option("ReadChecker", R.string.ReadChecker, false);
     public Option ReadCheckerChatdataDelete = new Option("ReadCheckerChatdataDelete", R.string.ReadCheckerChatdataDelete, false);
@@ -86,9 +85,8 @@ public class LimeOptions {
             stopVersionCheck,
             outputCommunication,
             DeviceCallTone,
-            DeviceDialTone,
             MuteCallTone,
-            MuteDialTone,
+            CustomDialTone,
             DarkColor,
             MuteGroup,
             PhotoAddNotification,GroupNotification,

--- a/app/src/main/java/io/github/hiro/lime/hooks/RingTone.java
+++ b/app/src/main/java/io/github/hiro/lime/hooks/RingTone.java
@@ -114,8 +114,11 @@ public class RingTone implements IHook {
                                                 return; // 再生中の場合は何もしない
                                             }
 
+                                            Uri customRingtoneUri = Uri.parse("file://" + Environment.getExternalStorageDirectory().getPath() + "/Notifications/LIME_Dialtone.mp3");
                                             Uri ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE);
-                                            ringtone = RingtoneManager.getRingtone(appContext, ringtoneUri);
+                                            if (isFileExists(customRingtoneUri)) {
+                                                ringtoneUri = customRingtoneUri;
+                                            }
 
                                             if (ringtone != null) {
                                                 //Log.d("Xposed", "Playing ringtone.");
@@ -155,5 +158,17 @@ public class RingTone implements IHook {
                 }
             }
         });
+    }
+
+    public boolean isFileExists(Uri uri) {
+        if (uri == null) {
+            return false;
+        }
+        String filePath = uri.getPath();
+        if (filePath == null) {
+            return false;
+        }
+        File file = new File(filePath);
+        return file.exists();
     }
 }

--- a/app/src/main/java/io/github/hiro/lime/hooks/RingTone.java
+++ b/app/src/main/java/io/github/hiro/lime/hooks/RingTone.java
@@ -22,7 +22,7 @@ public class RingTone implements IHook {
 
     @Override
     public void hook(LimeOptions limeOptions, XC_LoadPackage.LoadPackageParam loadPackageParam) throws Throwable {
-        if (!limeOptions.DeviceCallTone.checked && !limeOptions.DeviceDialTone.checked && !limeOptions.MuteCallTone.checked && !limeOptions.MuteDialTone.checked) {
+        if (!limeOptions.DeviceCallTone.checked && !limeOptions.MuteCallTone.checked && !limeOptions.CustomDialTone.checked) {
             return;
         }
 
@@ -69,7 +69,7 @@ public class RingTone implements IHook {
                             });
                 }
 
-                if (!limeOptions.DeviceDialTone.checked && !limeOptions.MuteCallTone.checked && !limeOptions.MuteDialTone.checked) {
+                if (!limeOptions.MuteCallTone.checked && !limeOptions.CustomDialTone.checked) {
                     return;
                 }
 
@@ -100,12 +100,10 @@ public class RingTone implements IHook {
 
                             if (method.getName().equals("processToneEvent")) {
                                 Object arg0 = param.args[0];
-                                if (limeOptions.MuteDialTone.checked) {
-                                    //Log.d("Xposed", "MuteTone is enabled. Suppressing tone event.");
+                                if (limeOptions.CustomDialTone.checked) {
+                                    //Log.d("Xposed", "MuteDialTone is enabled. Suppressing tone event.");
                                     param.setResult(null);
-                                }
 
-                                if (limeOptions.DeviceDialTone.checked) {
                                     if (arg0.toString().contains("START")) {
                                         if (appContext != null) {
                                             // ringtone が初期化されており、再生中の場合はスキップ

--- a/app/src/main/java/io/github/hiro/lime/hooks/RingTone.java
+++ b/app/src/main/java/io/github/hiro/lime/hooks/RingTone.java
@@ -117,6 +117,7 @@ public class RingTone implements IHook {
                                             if (isFileExists(customRingtoneUri)) {
                                                 ringtoneUri = customRingtoneUri;
                                             }
+                                            ringtone = RingtoneManager.getRingtone(appContext, ringtoneUri);
 
                                             if (ringtone != null) {
                                                 //Log.d("Xposed", "Playing ringtone.");

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -126,7 +126,6 @@
     <string name="Reader">既読者</string>
     <string name="Delete">削除</string>
     <string name="Reader_Data_Delete_Success">既読データが削除されました。</string>
-    <string name="callTone">本体の発着信音を鳴らす(LsPach用)</string>
     <string name="removeNotification">更新されたプロフィールを削除</string>
     <string name="AutomaticBackup">定期的にバックアップ</string>
     <string name="set_id">Set ID</string>
@@ -136,7 +135,6 @@
     <string name="edit_margin_settings">ボタンの設定</string>
     <string name="keep_unread_horizontalMarginFactor">横マージン (KeepUnread)</string>
     <string name="keep_unread_vertical">縦マージン (KeepUnread)</string>
-    <string name="DialTone">発信音を無効にする\n</string>
     <string name="Read_buttom_Chat_horizontalMarginFactor">チャット内の既読ボタン(横マージン)</string>
     <string name="Read_checker_horizontalMarginFactor">既読者確認ボタン(横マージン)</string>
     <string name="Read_checker_verticalMarginDp">既読者確認ボタン(縦マージン)</string>
@@ -152,6 +150,7 @@
     <string name="canceled_message">取り消されたメッセージのトークを変更する</string>
     <string name="canceled_message_txt">取り消しされたメッセージです</string>
     <string name="hide_canceled_message">取り消されたメッセージのお知らせメッセージを非表示にする</string>
+    <string name="DeviceCallTone">本体の発信音を鳴らす(LsPach用)</string>
 
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -150,7 +150,7 @@
     <string name="canceled_message">取り消されたメッセージのトークを変更する</string>
     <string name="canceled_message_txt">取り消しされたメッセージです</string>
     <string name="hide_canceled_message">取り消されたメッセージのお知らせメッセージを非表示にする</string>
-    <string name="DeviceCallTone">本体の発信音を鳴らす(LsPach用)</string>
+    <string name="DeviceCallTone">本体の着信音を鳴らす(LsPach用)</string>
 
 
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -116,7 +116,7 @@
 
     <string name="switch_BlockUpdateProfileNotification">不通知個人資料更新</string>
 
-    <string name="callTone">設備鈴聲（用於 LsPatch）</string>
+    <string name="DeviceCallTone">設備鈴聲（用於 LsPatch）</string>
     <string name="RemoveService">刪除服務項目</string>
     <string name="ReadChecker">檢查已發送訊息的讀者人數</string>
     <string name="removeNotification">刪除更新的設定文件</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,9 +41,8 @@
     <string name="switch_BlockUpdateProfileNotification">Do not notify of profile updates</string>
 
     <string name="MuteCallTone" translatable="false">(Root用)着信音のミュート</string>
-    <string name="MuteDialTone" translatable="false">(Root用)呼出音のミュート</string>
     <string name="DeviceCallTone">Device Ringtones(For LsPatch)</string>
-    <string name="DeviceDialTone" translatable="false">本体の呼出音を鳴らす(LsPach用)</string>
+    <string name="CustomDialTone" translatable="false">呼出音のカスタマイズ\n/sdcard/Notifications/LIME_Dialtone.mp3を再生します\nファイルがない場合は本体の着信音を再生します</string>
     <string name="RemoveService">Remove service item</string>
     <string name="ReadChecker">Check the readership of sent messages</string>
     <string name="removeNotification">Remove updated profiles\n</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,7 +40,10 @@
     <string name="switch_output_communication">Output communication contents to log (for developers)</string>
     <string name="switch_BlockUpdateProfileNotification">Do not notify of profile updates</string>
 
-    <string name="callTone">Device Ringtones(For LsPatch)</string>
+    <string name="MuteCallTone" translatable="false">(Root用)着信音のミュート</string>
+    <string name="MuteDialTone" translatable="false">(Root用)呼出音のミュート</string>
+    <string name="DeviceCallTone">Device Ringtones(For LsPatch)</string>
+    <string name="DeviceDialTone" translatable="false">本体の呼出音を鳴らす(LsPach用)</string>
     <string name="RemoveService">Remove service item</string>
     <string name="ReadChecker">Check the readership of sent messages</string>
     <string name="removeNotification">Remove updated profiles\n</string>


### PR DESCRIPTION
### 確認項目

<!--
以下の項目を全て確認し、満たしている場合は
[ ] を [x] に書き換えてください。
該当部分以外は書き換えないでください。
-->

- [x] <!-- Choice,multiple --> 動作確認済み
- [x] <!-- Choice,multiple --> 誤字脱字無し

---
### 説明
<!--
プルリクエストの詳細を記述してください。
-->

[issues提案内容](https://github.com/Chipppppppppp/LIME/issues/230#issuecomment-2585125486)を簡易的に実装してみました。
デバックについては、v14.19.1で検証しました。

### 発着信音の設定を分割
発着信を鳴らすではなく、着信音を鳴らすのみに変更しました。

### 呼出音のカスタマイズ
呼出音の無効化ではなく、呼出音のカスタマイズに変更しました。
/sdcard/Notifiction/LINE_Dialtone.mp3というファイルがあればそのファイルを再生する。
なければ従来通り本体の着信音を鳴らすようにしています。

本来であれば、Android標準の音楽選択画面(RingtoneManager.ACTION_RINGTONE_PICKER)を表示したかったのですが、Javaやモジュール環境での実装方法が分からないためこのような実装方法になりました。